### PR TITLE
Try using alias_method_chain style injection

### DIFF
--- a/lib/active_record-updated_at.rb
+++ b/lib/active_record-updated_at.rb
@@ -3,7 +3,7 @@ require_relative "active_record/updated_at/relation"
 
 module ActiveRecord
   module UpdatedAt
-    ActiveRecord::Relation.send(:prepend, Relation)
+    ActiveRecord::Relation.send(:include, Relation)
 
     STATE = "#{name}::DISABLED".freeze
 


### PR DESCRIPTION
Using `prepend` is conflicting with NewRelic's alias_method injection and causing `SystemStackError`.

https://github.com/newrelic/rpm/blob/master/lib/new_relic/agent/instrumentation/active_record_helper.rb#L41-L48